### PR TITLE
appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,9 @@ install:
     - if "%platform%"=="x64" set archi=amd64
     - if "%platform%"=="Win32" set archi=x86
     - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+    #force a package restoring
+    - del "%APPVEYOR_BUILD_FOLDER%"\packages\boost.1.63.0.0\boost.1.63.0.0.nupkg
+    - nuget restore "%APPVEYOR_BUILD_FOLDER%"\vs.proj\packages.config -PackagesDirectory "%APPVEYOR_BUILD_FOLDER%"\packages
 
 build:
     parallel: true                  # enable MSBuild parallel builds
@@ -25,18 +28,18 @@ build:
 
 build_script:
     - cd "%APPVEYOR_BUILD_FOLDER%"\vs.proj
-    - msbuild NppPluginTemplate.vcxproj /m /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%"
+    - msbuild NppPluginTemplate.vcxproj /m /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 after_build:
     - cd "%APPVEYOR_BUILD_FOLDER%"
     - ps: >-
 
         if ($env:PLATFORM -eq "x64" -and $env:CONFIGURATION -eq "Release") {
-            Push-AppveyorArtifact "bin64\RTLManager.dll" -FileName RTLManager.dll
+            #Push-AppveyorArtifact "bin64\RTLManager.dll" -FileName RTLManager.dll
         }
 
         if ($env:PLATFORM -eq "Win32" -and $env:CONFIGURATION -eq "Release") {
-            Push-AppveyorArtifact "bin\RTLManager.dll" -FileName RTLManager.dll
+            #Push-AppveyorArtifact "bin\RTLManager.dll" -FileName RTLManager.dll
         }
 
         if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v140_xp") {

--- a/src/Dialogs/HelpDialog.cpp
+++ b/src/Dialogs/HelpDialog.cpp
@@ -32,7 +32,7 @@ void HelpDialog::doDialog()
 }
 
 
-INT_PTR CALLBACK HelpDialog::run_dlgProc( UINT Message, WPARAM wParam, LPARAM lParam)
+INT_PTR CALLBACK HelpDialog::run_dlgProc( UINT Message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	switch (Message) 
 	{

--- a/src/Dialogs/HelpDialog.h
+++ b/src/Dialogs/HelpDialog.h
@@ -35,10 +35,10 @@ class HelpDialog : public StaticDialog
 public:
 	HelpDialog() : StaticDialog() {};
     
-    void init(HINSTANCE hInst, NppData nppData)
+    void init(HINSTANCE hInst, NppData nppDataParam)
 	{
-		_nppData = nppData;
-		Window::init(hInst, nppData._nppHandle);
+		_nppData = nppDataParam;
+		Window::init(hInst, nppDataParam._nppHandle);
 	};
 
    	void doDialog();

--- a/src/Dialogs/PrefDialog.h
+++ b/src/Dialogs/PrefDialog.h
@@ -41,10 +41,10 @@ class PrefDialog : public StaticDialog
 public:
 	PrefDialog() : StaticDialog() {};
 
-	void init(HINSTANCE hInst, NppData nppData)
+	void init(HINSTANCE hInst, NppData nppDataParam)
 	{
-		_nppData = nppData;
-		Window::init(hInst, nppData._nppHandle);
+		_nppData = nppDataParam;
+		Window::init(hInst, nppDataParam._nppHandle);
 	};
 
 	void doDialog();

--- a/vs.proj/NppPluginTemplate.vcxproj
+++ b/vs.proj/NppPluginTemplate.vcxproj
@@ -118,7 +118,7 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;NPPPLUGINTEMPLATE_EXPORTS;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>C:\boost_1_63_0;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>false</TreatWarningAsError>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4100</DisableSpecificWarnings>
@@ -127,7 +127,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>C:\boost_1_63_0\stage\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -137,7 +137,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;NPPPLUGINTEMPLATE_EXPORTS;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <TreatWarningAsError>false</TreatWarningAsError>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalIncludeDirectories>C:\boost_1_63_0;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -153,7 +153,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;NPPPLUGINTEMPLATE_EXPORTS;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>C:\boost_1_63_0;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>false</TreatWarningAsError>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4100</DisableSpecificWarnings>
@@ -165,11 +165,10 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImportLibrary>$(TargetName).lib</ImportLibrary>
-      <AdditionalLibraryDirectories>C:\boost_1_63_0\stage\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>copy ..\license.txt ..\bin\license.txt
-copy ..\readme.FIRST ..\bin\readme.FIRST</Command>
+      <Command>copy ..\license.txt ..\bin\license.txt</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -181,7 +180,7 @@ copy ..\readme.FIRST ..\bin\readme.FIRST</Command>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;NPPPLUGINTEMPLATE_EXPORTS;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <TreatWarningAsError>false</TreatWarningAsError>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalIncludeDirectories>C:\boost_1_63_0;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -193,8 +192,7 @@ copy ..\readme.FIRST ..\bin\readme.FIRST</Command>
       <AdditionalLibraryDirectories>C:\boost_1_63_0\stage\x64\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>copy ..\license.txt ..\bin64\license.txt
-copy ..\readme.FIRST ..\bin64\readme.FIRST</Command>
+      <Command>copy ..\license.txt ..\bin64\license.txt</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
ATTENTION: This requires a correct package of boost from nuget
- removed include and local libs under C:\boost_1_63_0 from vcxproj and just depend on nuget package, which is currently just partly checked in and has therefore issues in restoring as VS says it is already there


- add appveyor with nuget restore of boost
- added MSBuildLogger for infos on messages tab
- fixes some compiler warnings
- removed copy step on release builds of nonexistent readme.FIRST


, see https://ci.appveyor.com/project/chcg/rtlmanager-1/build/0.8.17

